### PR TITLE
fix: do not allow 7 for day_of_week

### DIFF
--- a/lib/cron_to_go_sync/parser.rb
+++ b/lib/cron_to_go_sync/parser.rb
@@ -39,7 +39,7 @@ module CronToGoSync
         unless (error = valid_cron_field(fields[3], 1, 12)).nil?
           key.failure("in month: #{error}")
         end
-        unless (error = valid_cron_field(fields[4], 0, 7)).nil?
+        unless (error = valid_cron_field(fields[4], 0, 6)).nil?
           key.failure("in day of week: #{error}")
         end
       end


### PR DESCRIPTION
In standard vixie cron, you can call Sunday either 0 or 7; however, CronToGo only allows 0 and returns a 422 if your cron expression has 7 as a day of week.