### PR TITLE
fix: validator for ranges

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/cron_to_go_sync/parser.rb
+++ b/lib/cron_to_go_sync/parser.rb
@@ -68,7 +68,8 @@ module CronToGoSync
             lower = lower.to_i
             upper = upper.to_i
             return "invalid range lower #{lower}" if lower < lower_limit || lower > upper_limit
-            return "invalid range upper #{upper}" if upper < upper_limit || upper > upper_limit
+            return "invalid range upper #{upper}" if upper < lower_limit || upper > upper_limit
+            return "range not in order" if upper <= lower
           elsif !range.match?(/\A[0-9]+\z/)
             return "invalid range value #{range}"
           else

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -30,5 +30,21 @@ RSpec.describe CronToGoSync::Parser do
       input_hash = {"job_name" => {schedule: "*/99 * * * *", enabled: true, ttl: 86400, dyno_size: "Basic", command: "/bin/true"}}
       expect { described_class.parse_hash(input_hash) }.to raise_error(RuntimeError, /invalid denominator value/)
     end
+
+    it "validates schedule range" do
+      input_hash = {"job_name" => {schedule: "* * * * 1-5", enabled: true, ttl: 86400, dyno_size: "Basic", command: "/bin/true"}}
+      parsed = described_class.parse_hash(input_hash)
+      expect(parsed["job_name"][:schedule]).to eq "* * * * 1-5"
+    end
+
+    it "validates schedule range values" do
+      input_hash = {"job_name" => {schedule: "* * * * 1-9", enabled: true, ttl: 86400, dyno_size: "Basic", command: "/bin/true"}}
+      expect { described_class.parse_hash(input_hash) }.to raise_error(RuntimeError, /invalid range upper/)
+    end
+
+    it "validates schedule range order" do
+      input_hash = {"job_name" => {schedule: "* * * * 5-1", enabled: true, ttl: 86400, dyno_size: "Basic", command: "/bin/true"}}
+      expect { described_class.parse_hash(input_hash) }.to raise_error(RuntimeError, /range not in order/)
+    end
   end
 end


### PR DESCRIPTION
This is rejecting valid ranges because of the `lower` / `upper` typo. Fix fix.