### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# CronToGo Sync
+
+> [!WARNING]
+> **This repository is archived and no longer maintained.**
+>
+> We are migrating away from CronToGo and will no longer be maintaining this gem. This repository is now read-only and will not receive updates, bug fixes, or security patches.
+>
+> **If you need to continue using this gem:**
+> - Feel free to fork this repository and maintain your own version
+> - No support, updates, or security patches will be provided by the original maintainers
+
 This repository contains a Ruby library for synchronizing a checked-in YAML file with [CronToGo](https://crontogo.com/).
 
 CronToGo is a trademark of Crazy Ant Labs; this library is an independent work and is not endorsed by or maintained


### PR DESCRIPTION
## Summary

Adds an archive notice to the README in preparation for archiving this repository. We are migrating away from CronToGo and will no longer maintain this gem.

## Changes

- Added title "CronToGo Sync" to README
- Added prominent WARNING callout notifying users that the repository is archived
- Encourages users to fork the repository if they need to continue using the gem